### PR TITLE
Fix: function usedMemory

### DIFF
--- a/app/lib/system.php
+++ b/app/lib/system.php
@@ -42,7 +42,7 @@ class Sysinfo
 
     public function usedMemory()
     {
-        $used = shell_exec("free -m | awk '/Mem:/ { total=$2 ; used=$3 } END { print used/total*100}'");
+        $used = shell_exec("free -m | awk 'NR==2{ total=$2 ; used=$3 } END { print used/total*100}'");
         return floor($used);
     }
 


### PR DESCRIPTION
While language in console is not English, this function may return `nan`